### PR TITLE
Integrate `plugin-rescript`

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "react-dom": "^17.0.2"
   },
   "devDependencies": {
+    "@jihchi/plugin-rescript": "0.0.0",
     "@snowpack/plugin-dotenv": "^2.1.0",
     "@snowpack/plugin-react-refresh": "^2.4.2",
     "@snowpack/plugin-run-script": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "react-dom": "^17.0.2"
   },
   "devDependencies": {
-    "@jihchi/plugin-rescript": "0.0.0",
+    "@jihchi/plugin-rescript": "^1.0.0",
     "@snowpack/plugin-dotenv": "^2.1.0",
     "@snowpack/plugin-react-refresh": "^2.4.2",
     "@snowpack/web-test-runner-plugin": "^0.2.2",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,6 @@
     "@web/test-runner": "^0.12.19",
     "chai": "^4.3.4",
     "rescript": "^9.1.1",
-    "snowpack": "^3.3.3"
+    "snowpack": "~3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "@jihchi/plugin-rescript": "0.0.0",
     "@snowpack/plugin-dotenv": "^2.1.0",
     "@snowpack/plugin-react-refresh": "^2.4.2",
-    "@snowpack/plugin-run-script": "^2.3.0",
     "@snowpack/web-test-runner-plugin": "^0.2.2",
     "@testing-library/react": "^11.2.6",
     "@web/test-runner": "^0.12.19",

--- a/package.json
+++ b/package.json
@@ -30,10 +30,8 @@
     "access": "public"
   },
   "scripts": {
-    "build": "npm run build:res && snowpack build",
-    "build:res": "rescript build",
-    "clean": "npm run clean:res",
-    "clean:res": "rescript clean",
+    "build": "snowpack build",
+    "clean": "rescript clean",
     "start": "snowpack dev",
     "test": "web-test-runner \"src/**/__tests__/*.bs.js\""
   },

--- a/snowpack.config.js
+++ b/snowpack.config.js
@@ -8,13 +8,7 @@ module.exports = {
   plugins: [
     '@snowpack/plugin-react-refresh',
     '@snowpack/plugin-dotenv',
-    [
-      '@snowpack/plugin-run-script',
-      {
-        cmd: 'npm run build:res',
-        watch: '$1 -- -w',
-      },
-    ],
+    '@jihchi/plugin-rescript',
   ],
   packageOptions: {
     /* ... */


### PR DESCRIPTION
- Integrate [`@jihchi/plugin-rescript`](https://github.com/jihchi/plugin-rescript) and deprecate @snowpack/plugin-run-script 
- Downgrade and stick snowpack version to `3.0.x` because of a regression in `build` stage, see https://github.com/snowpackjs/snowpack/issues/3095